### PR TITLE
(Feat): Missing getters and setters

### DIFF
--- a/contracts/index/src/contract.rs
+++ b/contracts/index/src/contract.rs
@@ -21,6 +21,27 @@ use crate::storage::set_public;
 use crate::storage::set_total_mints;
 use crate::storage::set_factory;
 use crate::storage::{
+    get_factory,
+    get_base_nav,
+    get_initial_price,
+    set_base_nav,
+    set_initial_price,
+    get_public,
+    get_rebalance_threshold,
+    set_rebalance_threshold,
+    get_last_rebalance_ts,
+    get_last_updated_ts,
+    get_total_mints,
+    get_total_redemptions,
+    get_component,
+    get_component_balance,
+    get_last_fee_collection,
+    get_whitelist_status,
+    get_blacklist_status,
+    set_whitelist_status,
+    set_blacklist_status,
+};
+use crate::storage::{
     get_manager_fee_fraction,
     get_manager_address,
     get_protocol_fee_recipient,
@@ -195,7 +216,7 @@ impl IndexTrait for Index {
         validate!(
             &e,
             !(insurance_vault_amount == 0 && total_shares != 0),
-            InsuranceFundError::InvalidIFForNewStakes
+            IndexError::MaxIFWithdrawReached
         );
 
         // Collect manager fees from the deposit amount
@@ -232,6 +253,99 @@ impl IndexTrait for Index {
         if get_is_killed_redeem(&e) {
             panic_with_error!(e, IndexError::IndexRedeemKilled);
         }
+    }
+
+    fn get_token(e: Env) -> Address {
+        crate::storage::get_token(&e)
+    }
+
+    fn get_factory(e: Env) -> Address {
+        crate::storage::get_factory(&e)
+    }
+
+    fn get_base_nav(e: Env) -> i128 {
+        crate::storage::get_base_nav(&e)
+    }
+
+    fn get_initial_price(e: Env) -> i128 {
+        crate::storage::get_initial_price(&e)
+    }
+
+    fn get_nav(e: Env) -> i128 {
+        let base_nav = crate::storage::get_base_nav(&e);
+        let total_shares = crate::storage::get_total_shares(&e);
+        if total_shares == 0 {
+            return base_nav;
+        }
+        
+        let token = crate::storage::get_token(&e);
+        let vault_amount = crate::storage::get_index_vault_amount(&e, &token) as i128;
+        vault_amount
+    }
+
+    fn get_price(e: Env) -> i128 {
+        let nav = Self::get_nav(e.clone());
+        let total_shares = crate::storage::get_total_shares(&e);
+        if total_shares == 0 {
+            return crate::storage::get_initial_price(&e);
+        }
+        nav / (total_shares as i128)
+    }
+
+    fn get_total_shares(e: Env) -> u128 {
+        crate::storage::get_total_shares(&e)
+    }
+
+    fn get_public_status(e: Env) -> bool {
+        crate::storage::get_public(&e)
+    }
+
+    fn get_whitelist_status(e: Env, address: Address) -> bool {
+        crate::storage::get_whitelist_status(&e, &address)
+    }
+
+    fn get_blacklist_status(e: Env, address: Address) -> bool {
+        crate::storage::get_blacklist_status(&e, &address)
+    }
+
+    fn get_manager_fee_fraction(e: Env) -> u32 {
+        crate::storage::get_manager_fee_fraction(&e)
+    }
+
+    fn get_rebalance_threshold(e: Env) -> u64 {
+        crate::storage::get_rebalance_threshold(&e)
+    }
+
+    fn get_last_rebalance_timestamp(e: Env) -> u64 {
+        crate::storage::get_last_rebalance_ts(&e)
+    }
+
+    fn get_last_updated_timestamp(e: Env) -> u64 {
+        crate::storage::get_last_updated_ts(&e)
+    }
+
+    fn get_total_mints(e: Env) -> u128 {
+        crate::storage::get_total_mints(&e)
+    }
+
+    fn get_total_redemptions(e: Env) -> u128 {
+        crate::storage::get_total_redemptions(&e)
+    }
+
+    fn get_total_fees(e: Env) -> u128 {
+        crate::storage::get_total_fees(&e)
+    }
+
+    fn get_component(e: Env, token: Address) -> crate::storage::Component {
+        crate::storage::get_component(&e, token)
+    }
+
+    fn get_component_balance(e: Env, token: Address) -> u128 {
+        crate::storage::get_component_balance(&e, token)
+    }
+
+    fn get_last_fee_collection(e: Env) -> u64 {
+        crate::storage::get_last_fee_collection(&e)
     }
 }
 
@@ -543,13 +657,68 @@ impl AdminInterface for Index {
         get_accumulated_protocol_fees(&e)
     }
 
-  
-    fn get_manager_address(e: Env) -> Address {
-        get_manager_address(&e)
+    fn set_factory(e: Env, admin: Address, factory: Address) {
+        admin.require_auth();
+        let access_control = AccessControl::new(&e);
+        access_control.assert_address_has_role(&admin, &Role::Admin);
+
+        crate::storage::set_factory(&e, &factory);
     }
 
-    fn get_protocol_fee_recipient(e: Env) -> Address {
-        get_protocol_fee_recipient(&e)
+    fn set_base_nav(e: Env, admin: Address, base_nav: i128) {
+        admin.require_auth();
+        let access_control = AccessControl::new(&e);
+        access_control.assert_address_has_role(&admin, &Role::Admin);
+
+        crate::storage::set_base_nav(&e, &base_nav);
+    }
+
+    fn set_initial_price(e: Env, admin: Address, initial_price: i128) {
+        admin.require_auth();
+        let access_control = AccessControl::new(&e);
+        access_control.assert_address_has_role(&admin, &Role::Admin);
+
+        crate::storage::set_initial_price(&e, &initial_price);
+    }
+
+    fn set_public_status(e: Env, admin: Address, public: bool) {
+        admin.require_auth();
+        let access_control = AccessControl::new(&e);
+        access_control.assert_address_has_role(&admin, &Role::Admin);
+
+        crate::storage::set_public(&e, &public);
+    }
+
+    fn set_whitelist_status(e: Env, admin: Address, address: Address, status: bool) {
+        admin.require_auth();
+        let access_control = AccessControl::new(&e);
+        access_control.assert_address_has_role(&admin, &Role::Admin);
+
+        crate::storage::set_whitelist_status(&e, &address, status);
+    }
+
+    fn set_blacklist_status(e: Env, admin: Address, address: Address, status: bool) {
+        admin.require_auth();
+        let access_control = AccessControl::new(&e);
+        access_control.assert_address_has_role(&admin, &Role::Admin);
+
+        crate::storage::set_blacklist_status(&e, &address, status);
+    }
+
+    fn set_manager_fee_fraction(e: Env, admin: Address, fee_fraction: u32) {
+        admin.require_auth();
+        let access_control = AccessControl::new(&e);
+        access_control.assert_address_has_role(&admin, &Role::Admin);
+
+        crate::storage::set_manager_fee_fraction(&e, &fee_fraction);
+    }
+
+    fn set_rebalance_threshold(e: Env, admin: Address, threshold: u64) {
+        admin.require_auth();
+        let access_control = AccessControl::new(&e);
+        access_control.assert_address_has_role(&admin, &Role::Admin);
+
+        crate::storage::set_rebalance_threshold(&e, &threshold);
     }
 }
 

--- a/contracts/index/src/index.rs
+++ b/contracts/index/src/index.rs
@@ -1,9 +1,10 @@
-use soroban_sdk::{ Env, Vec, Address, IntoVal, Symbol, String, contracttype };
+use soroban_sdk::{ Env, Vec, Address, IntoVal, Symbol, String, contracttype, panic_with_error };
 use utils::{ constant::FIVE_MINUTE, math::safe_math::SafeMath, validate };
 use soroban_fixed_point_math::FixedPoint;
 
 use crate::storage::{ get_all_components, get_component_balance, get_index_vault_amount, get_factory };
 use crate::events::{Events, IndexEvents};
+use crate::errors::IndexError;
 
 #[derive(Clone)]
 #[contracttype]
@@ -118,7 +119,7 @@ pub fn vault_amount_to_shares(
         validate!(
             e,
             total_shares == 0,
-            InsuranceFundError::InvalidIFSharesDetected
+            IndexError::MaxIFWithdrawReached
         );
 
         amount

--- a/contracts/index/src/interface.rs
+++ b/contracts/index/src/interface.rs
@@ -3,9 +3,6 @@ use soroban_sdk::{ Address, Env };
 use crate::stake::Stake;
 
 pub trait IndexTrait {
-    // fn get_total_shares(e: Env) -> u128;
-
-    //
     fn mint(
         e: Env,
         user: Address,
@@ -15,45 +12,103 @@ pub trait IndexTrait {
         max_slippage: Option<u64>
     );
 
-    //
     fn redeem(e: Env, user: Address, share_amount: u128);
+
+
+    fn get_token(e: Env) -> Address;
+
+    fn get_factory(e: Env) -> Address;
+
+    fn get_base_nav(e: Env) -> i128;
+
+    fn get_initial_price(e: Env) -> i128;
+
+    fn get_nav(e: Env) -> i128;
+
+    fn get_price(e: Env) -> i128;
+
+    fn get_total_shares(e: Env) -> u128;
+
+    fn get_public_status(e: Env) -> bool;
+
+    fn get_whitelist_status(e: Env, address: Address) -> bool;
+
+    fn get_blacklist_status(e: Env, address: Address) -> bool;
+
+    fn get_manager_fee_fraction(e: Env) -> u32;
+
+    fn get_rebalance_threshold(e: Env) -> u64;
+
+    fn get_last_rebalance_timestamp(e: Env) -> u64;
+
+    fn get_last_updated_timestamp(e: Env) -> u64;
+
+    fn get_total_mints(e: Env) -> u128;
+
+    fn get_total_redemptions(e: Env) -> u128;
+
+    fn get_total_fees(e: Env) -> u128;
+
+    fn get_component(e: Env, token: Address) -> crate::storage::Component;
+
+    fn get_component_balance(e: Env, token: Address) -> u128;
+
+    fn get_last_fee_collection(e: Env) -> u64;
 }
 
 pub trait AdminInterface {
-    //
     fn initialize(e: Env, admin: Address, token: Address);
-
-    // Set unstaking period
-    fn set_unstaking_period(e: Env, admin: Address, unstaking_period: u64);
-
-    // Set max insurance
-    fn set_max_shares(e: Env, admin: Address, max_shares: u128);
 
     fn rebalance(e: Env, admin: Address);
 
-    // Stop staking instantly
+    fn distribute_manager_fees(e: Env, admin: Address);
+    
+    fn distribute_protocol_fees(e: Env, admin: Address);
+
+    fn set_factory(e: Env, admin: Address, factory: Address);
+
+    fn set_base_nav(e: Env, admin: Address, base_nav: i128);
+
+    fn set_initial_price(e: Env, admin: Address, initial_price: i128);
+
+    fn set_public_status(e: Env, admin: Address, public: bool);
+
+    fn set_whitelist_status(e: Env, admin: Address, address: Address, status: bool);
+
+    fn set_blacklist_status(e: Env, admin: Address, address: Address, status: bool);
+
+    fn set_manager_address(e: Env, admin: Address, manager: Address);
+
+    fn set_protocol_fee_recipient(e: Env, admin: Address, recipient: Address);
+
+    fn set_manager_fee_fraction(e: Env, admin: Address, fee_fraction: u32);
+
+    fn set_rebalance_threshold(e: Env, admin: Address, threshold: u64);
+
+    fn set_unstaking_period(e: Env, admin: Address, unstaking_period: u64);
+
+    fn set_max_shares(e: Env, admin: Address, max_shares: u128);
+
+    //    _______     __       ____  ____   ________  _______  ________
+    //   |   __ "\   /""\     ("  _||_ " | /"       )/"     "||"      "\
+    //   (. |__) :) /    \    |   (  ) : |(:   \___/(: ______)(.  ___  :)
+    //   |:  ____/ /' /\  \   (:  |  | . ) \___  \   \/    |  |: \   ) ||
+    //   (|  /    //  __'  \   \\ \__/ //   __/  \\  // ___)_ (| (___\ ||
+    //  /|__/ \  /   /  \\  \  /\\ __ //\  /" \   :)(:      "||:       :)
+    // (_______)(___/    \___)(__________)(_______/  \_______)(________/
+
     fn kill_mint(e: Env, admin: Address);
     fn kill_redeem(e: Env, admin: Address);
     fn kill_rebalance(e: Env, admin: Address);
 
-    // Resume staking
     fn unkill_mint(e: Env, admin: Address);
     fn unkill_redeem(e: Env, admin: Address);
     fn unkill_rebalance(e: Env, admin: Address);
 
-    // Get killswitch status
     fn get_is_killed_mint(e: Env) -> bool;
     fn get_is_killed_redeem(e: Env) -> bool;
     fn get_is_killed_rebalance(e: Env) -> bool;
 
-    fn set_manager_address(e: Env, admin: Address, manager: Address);
-    fn set_protocol_fee_recipient(e: Env, admin: Address, recipient: Address);
-    fn distribute_manager_fees(e: Env, admin: Address);
-    fn distribute_protocol_fees(e: Env, admin: Address);
-    
-    // Revenue Share Getters
     fn get_accumulated_manager_fees(e: Env) -> u128;
     fn get_accumulated_protocol_fees(e: Env) -> u128;
-    fn get_manager_address(e: Env) -> Address;
-    fn get_protocol_fee_recipient(e: Env) -> Address;
 }

--- a/contracts/index/src/storage.rs
+++ b/contracts/index/src/storage.rs
@@ -57,6 +57,10 @@ enum DataKey {
 
 generate_instance_storage_getter_and_setter_with_default!(factory, DataKey::Factory, Address, Address::from_str(&Env::default(), ""));
 
+// Financial Configuration
+generate_instance_storage_getter_and_setter_with_default!(base_nav, DataKey::BaseNAV, i128, 0);
+generate_instance_storage_getter_and_setter_with_default!(initial_price, DataKey::InitialPrice, i128, 0);
+
 // State
 generate_instance_storage_getter_and_setter_with_default!(
     total_shares,
@@ -110,6 +114,61 @@ generate_instance_storage_getter_and_setter_with_default!(
     u64,
     THIRTY_DAY
 );
+
+// Whitelist/Blacklist functions
+// Note: These use manual implementation (not macros) because they are keyed storage patterns
+// that require persistent storage, custom TTL management, and Address-based keys.
+// This follows the same pattern as Component(Address) and ComponentBalance(Address) storage.
+
+/// Checks if an address is whitelisted
+/// Returns true if whitelisted, false if not (missing entries are treated as not whitelisted)
+pub fn get_whitelist_status(e: &Env, address: &Address) -> bool {
+    let key = DataKey::Whitelist(address.clone());
+    match e.storage().persistent().get::<DataKey, Address>(&key) {
+        Some(_) => {
+            bump_persistent(e, &key);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Sets whitelist status for an address
+/// If status is true, adds the address to whitelist; if false, removes it
+pub fn set_whitelist_status(e: &Env, address: &Address, status: bool) {
+    let key = DataKey::Whitelist(address.clone());
+    if status {
+        e.storage().persistent().set(&key, address);
+        e.storage().persistent().extend_ttl(&key, 100000, 100000);
+    } else {
+        e.storage().persistent().remove(&key);
+    }
+}
+
+/// Checks if an address is blacklisted
+/// Returns true if blacklisted, false if not (missing entries are treated as not blacklisted)
+pub fn get_blacklist_status(e: &Env, address: &Address) -> bool {
+    let key = DataKey::Blacklist(address.clone());
+    match e.storage().persistent().get::<DataKey, Address>(&key) {
+        Some(_) => {
+            bump_persistent(e, &key);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Sets blacklist status for an address  
+/// If status is true, adds the address to blacklist; if false, removes it
+pub fn set_blacklist_status(e: &Env, address: &Address, status: bool) {
+    let key = DataKey::Blacklist(address.clone());
+    if status {
+        e.storage().persistent().set(&key, address);
+        e.storage().persistent().extend_ttl(&key, 100000, 100000);
+    } else {
+        e.storage().persistent().remove(&key);
+    }
+}
 
 // Timestamps
 generate_instance_storage_getter_and_setter_with_default!(


### PR DESCRIPTION
In this PR, I have added missing getters and setters for contracts, interfaces and storage files.

Some follow macros while some don't depending upon the type of in-contract storage (single instance vs keyed)
Pattern is exactly picked from the existing codebase